### PR TITLE
 Write cert info to configurable file name 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,8 @@ open serverless.yml and add the following:
                 idempotencyToken: 'abcsomedomainio' //optional
                 hostedZoneName: 'somedomain.io.' //required if hostedZoneId is not set
                 hostedZoneId: 'XXXXXXXXX' //required if hostedZoneName is not set
-                writeCertInfoToFile: false // optional default is false. if you set it to true you will get a new file called cert-info.yml (after executing serverless create-cert), that contains certificate info that you can use in your deploy pipeline
+                writeCertInfoToFile: false // optional default is false. if you set it to true you will get a new file (after executing serverless create-cert), that contains certificate info that you can use in your deploy pipeline
+                certInfoFileName: 'cert-info.yml' // optional, only used when writeCertInfoToFile is set to true. It sets the name of the file containing the cert info
                 region: eu-west-1 // optional - default is us-east-1 which is required for custom api gateway domains of Type Edge (default)
 
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class CreateCertificatePlugin {
         this.acm = new this.serverless.providers.aws.sdk.ACM(acmCredentials);
         this.idempotencyToken = this.serverless.service.custom.customCertificate.idempotencyToken;
         this.writeCertInfoToFile = this.serverless.service.custom.customCertificate.writeCertInfoToFile || false;
-
+        this.certInfoFileName = this.serverless.service.custom.customCertificate.certInfoFileName || 'cert-info.yml';
       }
 
       this.initialized = true;
@@ -95,7 +95,7 @@ class CreateCertificatePlugin {
   writeCertificateInfoToFile(certificateArn) {
     const info = {CertificateArn: certificateArn, Domain: this.domain}
     if (this.writeCertInfoToFile) {
-      fs.writeFileSync('cert-info.yml', YAML.stringify(info));
+      fs.writeFileSync(this.certInfoFileName, YAML.stringify(info));
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ class CreateCertificatePlugin {
   writeCertificateInfoToFile(certificateArn) {
     const info = {CertificateArn: certificateArn, Domain: this.domain}
     if (this.writeCertInfoToFile) {
+      this.serverless.cli.log(`Writing certificate info to ${this.certInfoFileName}`);
       fs.writeFileSync(this.certInfoFileName, YAML.stringify(info));
     }
   }


### PR DESCRIPTION
Hello Bastian! I found your serverless plug-in to be extremely useful, the only thing missing for me was a way to handle certs for multiple stages while reusing them in my `serverless.yaml`

Following the resolution of https://github.com/schwamster/serverless-certificate-creator/issues/4 I added a simple param to specify where to output the cert info, so it can be used like such:
```
    writeCertInfoToFile: true
    certInfoFileName: 'certs/${opt:stage, self:provider.stage}.yaml'
```

I hope you'll find this addition worth merging, let me know if I need to tweak something!
