### PR TITLE
Write cert info to configurable file name, create parent directories

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,8 @@ open serverless.yml and add the following:
                 idempotencyToken: 'abcsomedomainio' //optional
                 hostedZoneName: 'somedomain.io.' //required if hostedZoneId is not set
                 hostedZoneId: 'XXXXXXXXX' //required if hostedZoneName is not set
-                writeCertInfoToFile: false // optional default is false. if you set it to true you will get a new file called cert-info.yml (after executing serverless create-cert), that contains certificate info that you can use in your deploy pipeline
+                writeCertInfoToFile: false // optional default is false. if you set it to true you will get a new file (after executing serverless create-cert), that contains certificate info that you can use in your deploy pipeline
+                certInfoFileName: 'cert-info.yml' // optional, only used when writeCertInfoToFile is set to true. It sets the name of the file containing the cert info
                 region: eu-west-1 // optional - default is us-east-1 which is required for custom api gateway domains of Type Edge (default)
 
 

--- a/index.js
+++ b/index.js
@@ -102,14 +102,13 @@ class CreateCertificatePlugin {
       CertificateArn: certificateArn,
       Domain: this.domain
     }
-    this.serverless.cli.log(`Writing certificate info to ${this.certInfoFileName}`);
-    const dirname = path.dirname(this.certInfoFileName);
     try {
-      mkdirp.sync(dirname);
+      mkdirp.sync(path.dirname(this.certInfoFileName));
+      this.serverless.cli.log(`Writing certificate info to ${this.certInfoFileName}`);
       fs.writeFileSync(this.certInfoFileName, YAML.stringify(info));
     } catch (error) {
-      this.serverless.cli.log(`Unable to create file in ${dirname}`);
-      console.log('problem', error);
+      this.serverless.cli.log(`Unable to write to ${this.certInfoFileName}`);
+      throw error;
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class CreateCertificatePlugin {
         this.acm = new this.serverless.providers.aws.sdk.ACM(acmCredentials);
         this.idempotencyToken = this.serverless.service.custom.customCertificate.idempotencyToken;
         this.writeCertInfoToFile = this.serverless.service.custom.customCertificate.writeCertInfoToFile || false;
-
+        this.certInfoFileName = this.serverless.service.custom.customCertificate.certInfoFileName || 'cert-info.yml';
       }
 
       this.initialized = true;
@@ -95,7 +95,7 @@ class CreateCertificatePlugin {
   writeCertificateInfoToFile(certificateArn) {
     const info = {CertificateArn: certificateArn, Domain: this.domain}
     if (this.writeCertInfoToFile) {
-      fs.writeFileSync('cert-info.yml', YAML.stringify(info));
+      fs.writeFileSync(this.certInfoFileName, YAML.stringify(info));
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ class CreateCertificatePlugin {
   writeCertificateInfoToFile(certificateArn) {
     const info = {CertificateArn: certificateArn, Domain: this.domain}
     if (this.writeCertInfoToFile) {
+      this.serverless.cli.log(`Writing certificate info to ${this.certInfoFileName}`);
       fs.writeFileSync(this.certInfoFileName, YAML.stringify(info));
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-certificate-creator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "argparse": {
@@ -17,7 +17,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "aws-sdk": {
@@ -51,7 +51,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -60,9 +60,9 @@
       "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "chalk": {
@@ -70,9 +70,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "color-convert": {
@@ -118,12 +118,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "has-flag": {
@@ -141,8 +141,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -165,7 +165,20 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
       }
     },
     "once": {
@@ -173,7 +186,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -206,7 +219,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "url": {
@@ -233,8 +246,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
@@ -247,8 +260,8 @@
       "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
       "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
       "requires": {
-        "argparse": "1.0.10",
-        "glob": "7.1.3"
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "aws-sdk": "^2.320.0",
     "chalk": "^2.4.1",
     "delay": "^4.0.1",
+    "mkdirp": "^0.5.1",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
Hello again, following https://github.com/schwamster/serverless-certificate-creator/pull/5, I added [mkdirp](https://www.npmjs.com/package/mkdirp) to automatically create any missing parent directory for `certInfoFileName` when needed