### PR TITLE
Region disable missing initialisation

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,14 +45,14 @@ class CreateCertificatePlugin {
         this.idempotencyToken = this.serverless.service.custom.customCertificate.idempotencyToken;
         this.writeCertInfoToFile = this.serverless.service.custom.customCertificate.writeCertInfoToFile || false;
         this.certInfoFileName = this.serverless.service.custom.customCertificate.certInfoFileName || 'cert-info.yml';
-      }
 
-      unsupportedRegionPrefixes.forEach(unsupportedRegionPrefix => {
-        if(this.region.startsWith(unsupportedRegionPrefix)){
-          console.log(`The configured region ${this.region} does not support ACM. Plugin disabled`);
-          this.enabled = false;
-        }
-      })
+        unsupportedRegionPrefixes.forEach(unsupportedRegionPrefix => {
+          if(this.region.startsWith(unsupportedRegionPrefix)){
+            console.log(`The configured region ${this.region} does not support ACM. Plugin disabled`);
+            this.enabled = false;
+          }
+        })
+      }
 
       this.initialized = true;
     }


### PR DESCRIPTION
`this.region` is undefined `unless` `this.enabled`

Fixes 30fdb88346dc386a3781e87dd7d8f21b0331bc16

Fixes

```
  Type Error ---------------------------------------------
 
  Cannot read property 'startsWith' of undefined
 
     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
 
  Stack Trace --------------------------------------------
 
TypeError: Cannot read property 'startsWith' of undefined
    at unsupportedRegionPrefixes.forEach.unsupportedRegionPrefix (node_modules/serverless-certificate-creator/index.js:51:24)
    at Array.forEach (<anonymous>)
    at CreateCertificatePlugin.initializeVariables (node_modules/serverless-certificate-creator/index.js:50:33)
    at CreateCertificatePlugin.certificateSummary (node_modules/serverless-certificate-creator/index.js:257:10)
```