### PR TITLE
Add new configuration property rewriteRecords

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ class CreateCertificatePlugin {
         this.acm = new this.serverless.providers.aws.sdk.ACM(acmCredentials);
         this.idempotencyToken = this.serverless.service.custom.customCertificate.idempotencyToken;
         this.writeCertInfoToFile = this.serverless.service.custom.customCertificate.writeCertInfoToFile || false;
+        this.rewriteRecords = this.serverless.service.custom.customCertificate.rewriteRecords || false;
         this.certInfoFileName = this.serverless.service.custom.customCertificate.certInfoFileName || 'cert-info.yml';
         this.subjectAlternativeNames = this.serverless.service.custom.customCertificate.subjectAlternativeNames || [];
         this.tags = this.serverless.service.custom.customCertificate.tags || {};
@@ -259,7 +260,7 @@ class CreateCertificatePlugin {
 
       let changes = certificate.Certificate.DomainValidationOptions.map((x) => {
         return {
-          Action: "CREATE",
+          Action: this.rewriteRecords ? "UPSERT" : "CREATE",
           ResourceRecordSet: {
             Name: x.ResourceRecord.Name,
             ResourceRecords: [


### PR DESCRIPTION
Adding rewriteRecords and setting it to true in customCertificate now allows rewriting the record in case the verification fails. This helped me during testing at least, but I could also see it being useful to others.

```
  customCertificate:
   rewriteRecords: true
```