### PR TITLE
#21 Support a remove-cert command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,6 +89,10 @@ now you can run:
 
         serverless create-cert
 
+To remove the certificate and delete the CNAME recordsets from route53, run:
+
+        serverless remove-cert
+
 # Combine with serverless-domain-manager
 
 If you combine this plugin with [serverless-domain-manager](https://github.com/amplify-education/serverless-domain-manager) you can automate the complete process of creating a custom domain with a certificate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-certificate-creator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Implemented a remove-cert command as suggested in https://github.com/schwamster/serverless-certificate-creator/issues/21. This deletes both the certificate and the CNAME dns validation records from Route53 that were added by create-cert.

Also fixed the outdated version in package-lock.json.