### PR TITLE
feat(hooks): automate deploy and remove hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,11 @@ class CreateCertificatePlugin {
 
     this.hooks = {
       'create-cert:create': this.createCertificate.bind(this),
+      'after:deploy:deploy': this.createCertificate.bind(this),
       'after:deploy:deploy': this.certificateSummary.bind(this),
       'after:info:info': this.certificateSummary.bind(this),
       'remove-cert:remove': this.deleteCertificate.bind(this),
+      'before:remove:remove': this.deleteCertificate.bind(this),
     };
 
     this.variableResolvers = {


### PR DESCRIPTION
If the same CloudFormation stack also creates the Route53 HostedZone, the plugin currently does not work.

This is because if you would first deploy the stack, the plugin returns an error in `certificateSummary` (because there is no certificate) and if you would first run `create-cert` there is no HostedZone to create the certificate for. A similar situation arises if you remove the stack before removing the certificate.

With this change, the certificate gets created _automatically_ after the HostedZone is deployed, but before the `certificateSummary` is ran. Upon removal, the certificate is removed before the HostedZone is removed.

If you don't agree with my choice to make the `sls deploy` and `sls remove` commands trigger the creation and removal of the certificate, we could also change the `certificateSummary` function, so that it does not throw an error when there is no certificate.