### PR TITLE
Fix broken variable resolution with ${certificate:name:CertificateArn…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -143,6 +143,11 @@ Since version 1.2.0 of this plugin you can use the following syntax to access th
 
         ${certificate:${self:custom.customCertificate.certificateName}:CertificateArn}
 
+If you are on version >= 2.27.0 of serverless & have elected to use the new variable resolver: `variablesResolutionMode: 20210219`.
+You must use the new supported syntax which is:
+
+        ${certificate:${self:custom.customCertificate.certificateName}.CertificateArn}
+
 see the serverless [docs](https://serverless.com/framework/docs/providers/aws/guide/plugins#custom-variable-types) for more information
 
 ### License

--- a/index.js
+++ b/index.js
@@ -483,7 +483,14 @@ class CreateCertificatePlugin {
   getCertificateProperty(src) {
     this.initializeVariables();
     let s, domainName, property;
-    if (this.serverless.configurationInput.variablesResolutionMode === 20210219) {
+
+    let useModernVariableResolver = false;
+    try {
+       // Earlier version of serverless may not have 'configurationInput' property
+      useModernVariableResolver = this.serverless.configurationInput.variablesResolutionMode === 20210219
+    } catch(e) {}
+
+    if (useModernVariableResolver) {
       // User has set variablesResolutionMode: 20210219 (https://github.com/serverless/serverless/pull/8987/files)
       // Nested paths must be resolved with '.' instead of ':'
       const srcAsArray = src.split(':')[1].split('.');

--- a/index.js
+++ b/index.js
@@ -482,7 +482,17 @@ class CreateCertificatePlugin {
 
   getCertificateProperty(src) {
     this.initializeVariables();
-    let [s, domainName, property] = src.split(':');
+    let s, domainName, property;
+    if (this.serverless.configurationInput.variablesResolutionMode === 20210219) {
+      // User has set variablesResolutionMode: 20210219 (https://github.com/serverless/serverless/pull/8987/files)
+      // Nested paths must be resolved with '.' instead of ':'
+      const srcAsArray = src.split(':')[1].split('.');
+      property = srcAsArray.pop();
+      domainName = srcAsArray.join('.');
+    } else {
+      // Deprecated once Serverless V3 released & new variable resolver becomes the default.
+      [s, domainName, property] = src.split(':');
+    }
     return this.listCertificates()
       .then(({ CertificateSummaryList }) => {
         let cert = CertificateSummaryList.filter(({ DomainName }) => DomainName == domainName)[0];


### PR DESCRIPTION
2.27.0's has introduced the new variable resolver which will become the future default. Users on 2.27.0 can now elect to use the new resolver by adding variablesResolutionMode: 20210219 to the root of their serverless.yml. [Here](https://github.com/serverless/serverless/pull/8987/files) for more info. If they do this, `${certificate:${self:custom.customCertificate.certificateName}:CertificateArn}`. will cause a compilation failure because using ':' more than once is now illegal. The new syntax uses a '.' in place of this. I've added conditional logic to getCertificateProperty to resolve path when new resolver is being used.