### PR TITLE
Add support for variablesResolutionMode: 20210326

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -143,10 +143,15 @@ Since version 1.2.0 of this plugin you can use the following syntax to access th
 
         ${certificate:${self:custom.customCertificate.certificateName}:CertificateArn}
 
-If you are on version >= 2.27.0 of serverless & have elected to use the new variable resolver: `variablesResolutionMode: 20210219`.
-You must use the new supported syntax which is:
+If you are on version >= 2.27.0 of serverless & have elected to use the variable resolver: `variablesResolutionMode: 20210219`.
+You must use this supported syntax which is:
 
         ${certificate:${self:custom.customCertificate.certificateName}.CertificateArn}
+
+For the new variable resolver: `variablesResolutionMode: 20210326`:
+The new supported syntax is:
+
+        ${certificate(${self:custom.customCertificate.certificateName}):CertificateArn}
 
 see the serverless [docs](https://serverless.com/framework/docs/providers/aws/guide/plugins#custom-variable-types) for more information
 

--- a/index.js
+++ b/index.js
@@ -518,7 +518,7 @@ class CreateCertificatePlugin {
     });
   }
 
-  async getCertificateProperty({address, params, resolveConfigurationProperty, options}) {
+  async getCertificateProperty({address, params}) {
 
     const property = address
     const domainName = params[0]

--- a/index.js
+++ b/index.js
@@ -42,7 +42,15 @@ class CreateCertificatePlugin {
 
     this.variableResolvers = {
       certificate: {
-        resolver: this.getCertificateProperty.bind(this),
+        resolver: this.getCertificatePropertyOld.bind(this),
+        isDisabledAtPrepopulation: true,
+        serviceName: 'serverless-certificate-creator depends on AWS credentials.'
+      }
+    };
+
+    this.configurationVariablesSources = {
+      certificate: {
+        resolve: this.getCertificateProperty.bind(this),
         isDisabledAtPrepopulation: true,
         serviceName: 'serverless-certificate-creator depends on AWS credentials.'
       }
@@ -510,7 +518,38 @@ class CreateCertificatePlugin {
     });
   }
 
-  getCertificateProperty(src) {
+  async getCertificateProperty({address, params, resolveConfigurationProperty, options}) {
+
+    const property = address
+    const domainName = params[0]
+
+    this.initializeVariables();
+    if (!this.enabled) {
+      return Promise.resolve('');
+    }
+
+    return this.listCertificates()
+      .then(certificates => {
+        let cert = certificates.filter(({ DomainName }) => DomainName == domainName)[0];
+        if (cert && cert[property]) {
+          return {
+            value: cert[property]
+          }
+        } else {
+          this.serverless.cli.consoleLog(chalk.yellow('Warning, certificate or certificate property was not found. Returning an empty string instead!'));
+          return {
+            value: ''
+          }
+        }
+      })
+      .catch(error => {
+        console.log(this.domain, this.region);
+        this.serverless.cli.log('Could not find certificate property attempting to create...');
+        throw error;
+      });
+  }
+
+  getCertificatePropertyOld(src) {
     this.initializeVariables();
     if (!this.enabled) {
       return Promise.resolve('');


### PR DESCRIPTION
Old version is currently deprecated and there were some changes in how custom configuration variables are called, specially in name convention and parameters.

https://www.serverless.com/framework/docs/providers/aws/guide/plugins/#custom-variable-types