### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,9 +63,11 @@ open serverless.yml and add the following:
                 //optional
                 idempotencyToken: 'abcsomedomainio'
                 //required if hostedZoneIds is not set, alternativly as an array
-                hostedZoneNames: 'somedomain.io.' 
+                hostedZoneNames: 
+                    - 'somedomain.io.' 
                 //required if hostedZoneNames is not set
-                hostedZoneIds: 'XXXXXXXXX'
+                hostedZoneIds: 
+                    - 'XXXXXXXXX'
                 // optional default is false. if you set it to true you will get a new file (after executing serverless create-cert), that contains certificate info that you can use in your deploy pipeline, alternativly as an array
                 writeCertInfoToFile: false 
                 // optional, only used when writeCertInfoToFile is set to true. It sets the name of the file containing the cert info
@@ -124,8 +126,10 @@ Open serverless.yml and add the following:
             customCertificate:
                 certificateName: 'abc.somedomain.io' //required
                 idempotencyToken: 'abcsomedomainio' //optional
-                hostedZoneNames: 'somedomain.io.' //required if hostedZoneIds is not set 
-                hostedZoneIds: 'XXXXXXXXX' //required if hostedZoneNames is not set
+                hostedZoneNames: 
+                    - 'somedomain.io.' //required if hostedZoneIds is not set 
+                hostedZoneIds: 
+                    - 'XXXXXXXXX' //required if hostedZoneNames is not set
                 region: eu-west-1 // optional - default is us-east-1 which is required for custom api gateway domains of Type Edge (default)
                 enabled: true // optional - default is true. For some stages you may not want to use certificates (and custom domains associated with it).
                 rewriteRecords: false


### PR DESCRIPTION
The issue was caused because of the wrong Readme example. After changing the hostedZoneIds params to array the certificate was created without the error.

https://github.com/schwamster/serverless-certificate-creator/blob/master/index.js#L82

Close #54

