### PR TITLE
AWS China region support

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@ const mkdirp = require('mkdirp');
 const semver = require('semver')
 var packageJson = require('./package.json');
 
-const unsupportedRegionPrefixes = ['cn-'];
-
 class CreateCertificatePlugin {
   getEchoTestValue(src) {
     return src.slice(5);
@@ -90,13 +88,6 @@ class CreateCertificatePlugin {
         this.certInfoFileName = customCertificate.certInfoFileName || 'cert-info.yml';
         this.subjectAlternativeNames = customCertificate.subjectAlternativeNames || [];
         this.tags = customCertificate.tags || {};
-
-        unsupportedRegionPrefixes.forEach(unsupportedRegionPrefix => {
-          if (this.region.startsWith(unsupportedRegionPrefix)) {
-            console.log(`The configured region ${this.region} does not support ACM. Plugin disabled`);
-            this.enabled = false;
-          }
-        })
       }
       this.initialized = true;
     }


### PR DESCRIPTION
It seems that the AWS China region restriction is not relevant anymore. 
AWS China supports ACM and Route53 in the `cn-northwest-1` region. 
See: https://www.amazonaws.cn/en/certificate-manager/

Tested this change in a project - it worked, so the change seems safe.