### PR TITLE
Return a null value instead of an empty string when a certificate is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -536,9 +536,9 @@ class CreateCertificatePlugin {
             value: cert[property]
           }
         } else {
-          this.serverless.cli.consoleLog(chalk.yellow('Warning, certificate or certificate property was not found. Returning an empty string instead!'));
+          this.serverless.cli.consoleLog(chalk.yellow('Warning, certificate or certificate property was not found. Returning a null value instead!'));
           return {
-            value: ''
+            value: null
           }
         }
       })


### PR DESCRIPTION
This would be useful in the case when someone would like to specify their own default value.

As a more specific use case, it will allow the lift plugin to be used with the certificate creator